### PR TITLE
Viðbót við 7. gr. um aukaaðalfundi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Dagskrá aðalfundar skal vera sem hér segir:
   7.  Kosning tveggja skoðunarmanna reikninga
   8.  Önnur mál
 
+Boða skal til aukaaðalfundar svo fljótt sem auðið er ef meirihluti stjórnar eða a.m.k. fjórðungur félagsmanna fer fram á það skriflega og leggur fram tillögu að dagskrá.
+
 ### 8. gr.
 Starfstímabil félagsins er almanaksárið. Á aðalfundi félagsins skal stjórn gera upp árangur liðins árs. Aðeins félagsmenn mega vera þátttakendur á aðalfundi.
 


### PR DESCRIPTION
Skilgreina möguleikann á því að bjóða til aukaaðalfundar, ýmist af meirihluta stjórnar eða a.m.k. fjórðungi félagsmanna.
